### PR TITLE
Add function to print GitHub repo owner.

### DIFF
--- a/src/MyStatsPackage.jl
+++ b/src/MyStatsPackage.jl
@@ -1,6 +1,10 @@
 module MyStatsPackage
 
-greet() = print("Hello World!")
-include("statistics_functions.jl")
-export rse_mean, rse_std, rse_tstat, StatResult
+    function printOwner()
+        println("alvorithm")
+    end
+
+
+    include("statistics_functions.jl")
+    export rse_mean, rse_std, rse_tstat, StatResult
 end # module MyStatsPackage


### PR DESCRIPTION
I removed the stale (default, from the generate template) `greet` function and instead added a function to report the GitHub owner of this repo.